### PR TITLE
Added total statements metric to avoid overlaps with coremetrics

### DIFF
--- a/plugin/src/main/scala/com/buransky/plugins/scoverage/measure/ScalaMetrics.scala
+++ b/plugin/src/main/scala/com/buransky/plugins/scoverage/measure/ScalaMetrics.scala
@@ -30,12 +30,13 @@ import scala.collection.mutable.ListBuffer
  * @author Rado Buransky
  */
 class ScalaMetrics extends Metrics {
-  override def getMetrics = ListBuffer(ScalaMetrics.statementCoverage, ScalaMetrics.coveredStatements).toList
+  override def getMetrics = ListBuffer(ScalaMetrics.statementCoverage, ScalaMetrics.coveredStatements, ScalaMetrics.totalStatements).toList
 }
 
 object ScalaMetrics {
   private val STATEMENT_COVERAGE_KEY = "scoverage"
   private val COVERED_STATEMENTS_KEY = "covered_statements"
+  private val TOTAL_STATEMENTS_KEY = "total_statements"
 
   lazy val statementCoverage = new Metric.Builder(STATEMENT_COVERAGE_KEY,
     "Statement coverage", ValueType.PERCENT)
@@ -55,4 +56,12 @@ object ScalaMetrics {
     .setDomain(CoreMetrics.DOMAIN_SIZE)
     .setFormula(new org.sonar.api.measures.SumChildValuesFormula(false))
     .create[java.lang.Integer]()
+    
+  lazy val totalStatements = new Metric.Builder(TOTAL_STATEMENTS_KEY,
+    "Total statements", Metric.ValueType.INT)
+    .setDescription("Number of all statements covered by tests and uncovered")
+    .setDirection(Metric.DIRECTION_BETTER)
+    .setQualitative(false)
+    .setDomain(CoreMetrics.DOMAIN_SIZE)
+    .create[java.lang.Integer]()        
 }

--- a/plugin/src/main/scala/com/buransky/plugins/scoverage/sensor/ScoverageSensor.scala
+++ b/plugin/src/main/scala/com/buransky/plugins/scoverage/sensor/ScoverageSensor.scala
@@ -114,7 +114,7 @@ class ScoverageSensor(settings: Settings, pathResolver: PathResolver, fileSystem
 
   private def analyseStatementCountForModule(module: Project, context: SensorContext): Long = {
     // Aggregate modules
-    context.getMeasure(module, CoreMetrics.STATEMENTS) match {
+    context.getMeasure(module, ScalaMetrics.totalStatements) match {
       case null =>
         log.debug(LogUtil.f("Module has no number of statements. [" + module.name + "]"))
         0
@@ -174,8 +174,7 @@ class ScoverageSensor(settings: Settings, pathResolver: PathResolver, fileSystem
 
   private def saveMeasures(context: SensorContext, resource: Resource, statementCoverage: StatementCoverage) {
     context.saveMeasure(resource, createStatementCoverage(statementCoverage.rate))
-    if (context.getMeasure(CoreMetrics.STATEMENTS) == null)
-      context.saveMeasure(resource, createStatementCount(statementCoverage.statementCount))
+    context.saveMeasure(resource, createStatementCount(statementCoverage.statementCount))
     context.saveMeasure(resource, createCoveredStatementCount(statementCoverage.coveredStatementsCount))
 
     log.debug(LogUtil.f("Save measures [" + statementCoverage.rate + ", " + statementCoverage.statementCount +
@@ -189,7 +188,7 @@ class ScoverageSensor(settings: Settings, pathResolver: PathResolver, fileSystem
 
     // Set line hits
     val coverage = CoverageMeasuresBuilder.create()
-    coveredLines.foreach { coveredLine =>
+      coveredLines.foreach { coveredLine =>
       coverage.setHits(coveredLine.line, coveredLine.hitCount)
     }
 
@@ -214,7 +213,7 @@ class ScoverageSensor(settings: Settings, pathResolver: PathResolver, fileSystem
     new Measure[T](ScalaMetrics.statementCoverage, rate)
 
   private def createStatementCount[T <: Serializable](statements: Int): Measure[T] =
-    new Measure(CoreMetrics.STATEMENTS, statements.toDouble, 0)
+    new Measure(ScalaMetrics.totalStatements, statements.toDouble, 0)
 
   private def createCoveredStatementCount[T <: Serializable](coveredStatements: Int): Measure[T] =
     new Measure(ScalaMetrics.coveredStatements, coveredStatements.toDouble, 0)


### PR DESCRIPTION
Hi,

thats the 3rd in a series of 3 pull request I tried to separate functionality a bit.
this one is independent of the others

The statements core metric is sometimes already filled by other plugins (probably Java plugins?) and reading out the values in the Sensor has been deprecated. I think it would be best to use a new metric to avoid conflicts with other (e.g. class file based) plugins.

The Pull Request implements this.

ok thats it (-.

Best Michael