### PR TITLE
ScoverageSensor: Do not prepend project name for getting sources.

### DIFF
--- a/plugin/src/main/scala/com/buransky/plugins/scoverage/sensor/ScoverageSensor.scala
+++ b/plugin/src/main/scala/com/buransky/plugins/scoverage/sensor/ScoverageSensor.scala
@@ -52,11 +52,11 @@ class ScoverageSensor(settings: Settings, pathResolver: PathResolver, fileSystem
     scoverageReportPath match {
       case Some(reportPath) =>
         // Single-module project
-        val srcOption = Option(settings.getString(project.getName() + ".sonar.sources"))
+        val srcOption = Option(settings.getString("sonar.sources"))
         val sonarSources = srcOption match {
           case Some(src) => src
           case None => {
-            log.warn(s"could not find settings key ${project.getName()}.sonar.sources assuming src/main/scala.")
+            log.warn(s"could not find settings key sonar.sources assuming src/main/scala.")
             "src/main/scala"
           }
         }


### PR DESCRIPTION
The configuration key for the sources of a single-module project does not contain the project name but this is what's currently happening when the sources path is looked up.

The project name may vary since Sonar Scanner appends the VCS branch name to the project name. So I would have to configure a sources configuration key for every branch while the original sonar.sources configuration key is never used - neither in single- nor in multi-module projects.

This change omits the inclusion of the project name into the sources path lookup.