### PR TITLE
Fix for the absolute paths issue

### DIFF
--- a/plugin/src/main/scala/com/buransky/plugins/scoverage/pathcleaner/BruteForceSequenceMatcher.scala
+++ b/plugin/src/main/scala/com/buransky/plugins/scoverage/pathcleaner/BruteForceSequenceMatcher.scala
@@ -71,8 +71,12 @@ class BruteForceSequenceMatcher(baseDir: File, sourcePath: String) extends PathS
   // mock able helpers that allow us to remove the dependency to the real file system during tests
   
   private[pathcleaner] def initSourceDir(): File = {
-    val sourceDir = new File(baseDir, sourcePath)
-    sourceDir
+    val sourceDir = new File(sourcePath)
+    if (sourceDir.isAbsolute) {
+      sourceDir
+    } else {
+      new File(baseDir, sourcePath)
+    }
   }
   
   private[pathcleaner] def initFilesMap(): Map[String, Seq[PathSeq]] = {

--- a/plugin/src/main/scala/com/buransky/plugins/scoverage/sensor/ScoverageSensor.scala
+++ b/plugin/src/main/scala/com/buransky/plugins/scoverage/sensor/ScoverageSensor.scala
@@ -19,6 +19,8 @@
  */
 package com.buransky.plugins.scoverage.sensor
 
+import java.io.File
+
 import com.buransky.plugins.scoverage.language.Scala
 import com.buransky.plugins.scoverage.measure.ScalaMetrics
 import com.buransky.plugins.scoverage.pathcleaner.{BruteForceSequenceMatcher, PathSanitizer}
@@ -183,8 +185,9 @@ class ScoverageSensor(settings: Settings, pathResolver: PathResolver, fileSystem
     
     val inputOption: Option[InputPath] = if (isFile) {
       val p = fileSystem.predicates()
+      val pathPredicate = if (new File(path).isAbsolute) p.hasAbsolutePath(path) else p.hasRelativePath(path)
       Option(fileSystem.inputFile(p.and(
-        p.hasRelativePath(path),
+        pathPredicate,
         p.hasLanguage(Scala.key),
         p.hasType(InputFile.Type.MAIN))))
     } else {

--- a/samples/maven/combined-scala-java-multi-module-sonar/pom.xml
+++ b/samples/maven/combined-scala-java-multi-module-sonar/pom.xml
@@ -71,7 +71,7 @@
             <plugin>
                 <groupId>org.scoverage</groupId>
                 <artifactId>scoverage-maven-plugin</artifactId>
-                <version>1.0.4</version>
+                <version>1.3.0</version>
                 <configuration>
                     <highlighting>true</highlighting>
                 </configuration>

--- a/samples/maven/combined-scala-java-sonar/pom.xml
+++ b/samples/maven/combined-scala-java-sonar/pom.xml
@@ -66,7 +66,7 @@
             <plugin>
                 <groupId>org.scoverage</groupId>
                 <artifactId>scoverage-maven-plugin</artifactId>
-                <version>1.0.4</version>
+                <version>1.3.0</version>
                 <configuration>
                     <highlighting>true</highlighting>
                 </configuration>


### PR DESCRIPTION
Should fix #29 : under circumstances, on Windows machines the paths will be absolute, and sensor and sequence matcher do not account for that.
The same problem persists in https://github.com/Sagacify/sonar-scala, and this fix worked fine there.