### PR TITLE
Removed ServerExtension which has been removed in Sonar7.3

### DIFF
--- a/plugin/src/main/scala/com/buransky/plugins/scoverage/ScoverageExtensionProvider.scala
+++ b/plugin/src/main/scala/com/buransky/plugins/scoverage/ScoverageExtensionProvider.scala
@@ -2,12 +2,12 @@ package com.buransky.plugins.scoverage
 
 import com.buransky.plugins.scoverage.language.Scala
 import org.sonar.api.resources.Languages
-import org.sonar.api.{Extension, ExtensionProvider, ServerExtension}
+import org.sonar.api.{Extension, ExtensionProvider}
 
 import scala.collection.JavaConversions._
 import scala.collection.mutable.ListBuffer
 
-class ScoverageExtensionProvider(languages: Languages) extends ExtensionProvider with ServerExtension {
+class ScoverageExtensionProvider(languages: Languages) extends ExtensionProvider {
   override def provide(): java.util.List[Class[_ <: Extension]] = {
     val result = ListBuffer[Class[_ <: Extension]]()
 


### PR DESCRIPTION
This interface has been removed from SonarQube 7.3 per https://github.com/deepy/sonar-crowd/issues/17